### PR TITLE
Fix Feed URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 # General Jekyll Config
 highlighter: rouge
-url: http://example.com
+url: http://dharmit.github.io/
 lsi: false
 exclude: [LICENSE, CNAME, README.md, .gitignore, Gemfile, Gemfile.lock]
 gems: [jemoji]


### PR DESCRIPTION
Refer - http://dharmit.github.io/atom.xml
At present its use default example.com which breaks my feedly :(

```
<entry>
<title>
Using Ansible conditionals to avoid repetitive downloads
</title>
<link href="http://example.com/blog/2016/04/08/ansible-register-when-avoid-downloads.html"/>
<updated>2016-04-08T00:00:00+00:00</updated>
<id>
http://example.com/blog/2016/04/08/ansible-register-when-avoid-downloads
</id>
```